### PR TITLE
add data files: testing certificates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include src/leap/common/testing/*.pem

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,9 @@
 leap.common
 ===========
+
+.. image:: https://pypip.in/v/leap.common/badge.png
+        :target: https://crate.io/packages/leap.common
+
 A collection of shared utils used by the several python LEAP subprojects.
 
 * leap.common.cert

--- a/changes/bug_add-data-files
+++ b/changes/bug_add-data-files
@@ -1,0 +1,1 @@
+  o Add data files to setup and manifest (certificates for tests)

--- a/setup.py
+++ b/setup.py
@@ -32,31 +32,42 @@ requirements = [
     "PyCrypto",
 ]
 
-
-dependency_links = [
-    "https://protobuf-socket-rpc.googlecode.com/files/protobuf.socketrpc-1.3.2.tar.gz#egg=protobuf.socketrpc"
-]
+#dependency_links = [
+    #"https://protobuf-socket-rpc.googlecode.com/files/protobuf.socketrpc-1.3.2.tar.gz#egg=protobuf.socketrpc"
+#]
 
 tests_requirements = [
     'mock',
 ]
 
-
-# XXX add classifiers, docs
+trove_classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    ("License :: OSI Approved :: GNU General "
+     "Public License v3 or later (GPLv3+)"),
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2.6",
+    "Programming Language :: Python :: 2.7",
+    "Topic :: Communications",
+    "Topic :: Security",
+    "Topic :: Utilities"
+]
 
 setup(
     name='leap.common',
     # If you change version, do it also in
     # src/leap/common/__init__.py
-    version='0.2.4',
+    version='0.2.5',
     url='https://leap.se/',
     license='GPLv3+',
     author='The LEAP Encryption Access Project',
     author_email='info@leap.se',
-    description='Common files used by the LEAP Client project.',
+    description='Common files used by the LEAP project.',
     long_description=(
         "Common files used by the LEAP Client project."
     ),
+    classifiers=trove_classifiers,
     namespace_packages=["leap"],
     package_dir={'': 'src'},
     # For now, we do not exclude tests because of the circular dependency
@@ -65,6 +76,7 @@ setup(
     packages=find_packages('src'),
     test_suite='leap.common.tests',
     install_requires=requirements,
-    dependency_links=dependency_links,
+    #dependency_links=dependency_links,
     tests_require=tests_requirements,
+    include_package_data=True
 )

--- a/src/leap/common/__init__.py
+++ b/src/leap/common/__init__.py
@@ -16,4 +16,4 @@ except ImportError:
 
 __all__ = ["certs", "check", "files", "events"]
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"


### PR DESCRIPTION
this adds some missing data files.
bumped version for temporarily uploading to pypi for the ci to work, but I think we could tag+upload 0.2.5 again after keymanager move is merged. 
