### PR TITLE
Check if schema exists before load a config.

### DIFF
--- a/changes/check-if-schema-exists
+++ b/changes/check-if-schema-exists
@@ -1,0 +1,1 @@
+  o Check if schema exists before load a config. Related to #3310.


### PR DESCRIPTION
Related to #3310.

It does not affect the existing code and adds a needed check for the #3310 feature.
