### PR TITLE
make leap_assert_type raise TypeError

### DIFF
--- a/changes/feature_leap-assert-type-raise-typerr
+++ b/changes/feature_leap-assert-type-raise-typerr
@@ -1,0 +1,1 @@
+  o leap_assert_type raises TypeError instead of calling assert.

--- a/src/leap/common/check.py
+++ b/src/leap/common/check.py
@@ -50,16 +50,17 @@ def leap_assert(condition, message=""):
 
 def leap_assert_type(var, expectedType):
     """
-    Helper assert check for a variable's expected type
+    Helper assert that checks for a variable's expected type.
 
     :param var: variable to check
     :type var: any
-    :param expectedType: type to check agains
-    :type expectedType: type
+    :param expectedType: type to check against
+    :type expectedType: type, or tuple of types
     """
-    leap_assert(isinstance(var, expectedType),
-                "Expected type %r instead of %r" %
-                (expectedType, type(var)))
+    if not isinstance(var, expectedType):
+        raise TypeError(
+            "Expected type %r instead of %r" %
+            (expectedType, type(var)))
 
 
 def leap_check(condition, message="", exception=Exception):


### PR DESCRIPTION
While reading about assertions the other day, I went back to the type assert.
What do you think? this way we also tackle the case of running the code without asserts.
