### PR TITLE
Consider different possibilities for tmpdir.

### DIFF
--- a/changes/bug_tempdir-alternatives
+++ b/changes/bug_tempdir-alternatives
@@ -1,0 +1,1 @@
+- Consider different possibilities for tmpdir. Related to #6631.

--- a/src/leap/common/testing/basetest.py
+++ b/src/leap/common/testing/basetest.py
@@ -77,6 +77,9 @@ class BaseLeapTest(unittest.TestCase):
         # XXX needs to adapt to non-linuces
         leap_assert(
             cls.tempdir.startswith('/tmp/leap_tests-') or
+            (cls.tempdir.startswith('/tmp/') and
+             cls.tempdir.startswith(tempfile.gettempdir()) and
+             'leap_tests-' in cls.tempdir) or
             cls.tempdir.startswith('/var/folder'),
             "beware! tried to remove a dir which does not "
             "live in temporal folder!")


### PR DESCRIPTION
In some systems the used tmp dir is like '/tmp/leap_tests-asdf' and in
others is like '/tmp/username/leap_tests-asdf'.
With this fix we protect the home dir and consider different possible
temp directories.