### PR TITLE
[bug] use dict keys to iterate

### DIFF
--- a/src/leap/common/events/client.py
+++ b/src/leap/common/events/client.py
@@ -184,7 +184,7 @@ class EventsClient(object):
         :type msg: list(str)
         """
         logger.debug("Handling event %s..." % event)
-        for uid in self._callbacks[event]:
+        for uid in self._callbacks[event].keys():
             callback = self._callbacks[event][uid]
             logger.debug("Executing callback %s." % uid)
             callback(event, *content)
@@ -351,7 +351,6 @@ class EventsClientThread(threading.Thread, EventsClient):
         :type tag: str
         """
         self._sub.socket.setsockopt(zmq.SUBSCRIBE, tag)
-
 
     def _unsubscribe(self, tag):
         """


### PR DESCRIPTION
We ran into a RuntimeError yesterday on this line, the callback can
modify this dict and make the iteration raise an error. Using keys
method to iterate is safer.
See
http://stackoverflow.com/questions/11941817/python-runtimeerror-dictionary-changed-size-during-iteration-how-to-avoid-th/11941855#11941855