### PR TITLE
[pkg] add pyzmq and txzmq dep versions

### DIFF
--- a/pkg/requirements.pip
+++ b/pkg/requirements.pip
@@ -2,7 +2,7 @@ jsonschema  #<=0.8 -- are we done with this conflict?
 dirspec
 pyopenssl
 python-dateutil
-pyzmq
-txzmq
+pyzmq>=14.4.1
+txzmq>=0.7.3
 
 #autopep8 -- ???


### PR DESCRIPTION
We need to explicitelly depend on minimum pyzmq and txzmq versions, because older ones available in debian repositories are not enough.