### PR TITLE
[bug] remove extraneous data from events logs

### DIFF
--- a/changes/bug_7130_remove-extraneous-data-from-events-logs
+++ b/changes/bug_7130_remove-extraneous-data-from-events-logs
@@ -1,0 +1,1 @@
+  o Remove extraneous data from events logs. Closes #7130.

--- a/src/leap/common/events/client.py
+++ b/src/leap/common/events/client.py
@@ -173,7 +173,7 @@ class EventsClient(object):
         :param content: The content of the event.
         :type content: list
         """
-        logger.debug("Sending event: (%s, %s)" % (event, content))
+        logger.debug("Emitting event: (%s, %s)" % (event, content))
         self._send(str(event) + b'\0' + pickle.dumps(content))
 
     def _handle_event(self, event, content):
@@ -368,7 +368,6 @@ class EventsClientThread(threading.Thread, EventsClient):
         :param data: The data to be sent.
         :type event: str
         """
-        logger.debug("Sending data: %s" % data)
         # add send() as a callback for ioloop so it works between threads
         self._loop.add_callback(lambda: self._push.send(data))
 


### PR DESCRIPTION
The emission of an event was being logged twice, and the second time was
logging the pickled content of the event. This pickled content contained line
breaks and other things that caused strange output on the client log.

This commit removes the second loggin of the event pickled content.

Closes #7130.