### PR TITLE
[feature] enforce TLSv1.2 on twisted http client

### DIFF
--- a/changes/feature_6391_enforce-TLSv1.2
+++ b/changes/feature_6391_enforce-TLSv1.2
@@ -1,0 +1,1 @@
+  o Enforce TLSv1.2 on twisted http downloader. Related to #6391.


### PR DESCRIPTION
Currently, the Leap platform runs on debian wheezy, whose versions of python
and openssl do provide TLSv1.2 but have poor control over the SSL/TLS version.
Because of that, we enforce TLS version on the client also.

Related: #6391.
