### PR TITLE
Bug/event tests

### DIFF
--- a/src/leap/common/events/txclient.py
+++ b/src/leap/common/events/txclient.py
@@ -112,6 +112,19 @@ class EventsTxClient(TxZmqClientComponent, EventsClient):
         """
         self._push.send(data)
 
+    def _run_callback(self, callback, event, content):
+        """
+        Run a callback.
+
+        :param callback: The callback to be run.
+        :type callback: callable(event, *content)
+        :param event: The event to be sent.
+        :type event: Event
+        :param content: The content of the event.
+        :type content: list
+        """
+        callback(event, *content)
+
     def shutdown(self):
         TxZmqClientComponent.shutdown(self)
         EventsClient.shutdown(self)

--- a/src/leap/common/events/zmq_components.py
+++ b/src/leap/common/events/zmq_components.py
@@ -128,9 +128,9 @@ class TxZmqComponent(object):
 
         proto, addr, port = ADDRESS_RE.search(address).groups()
 
-        if port is None:
+        if port is None or port is '0':
             params = proto, addr
-            port = socket.bind("%s://%s" % params)
+            port = socket.bind_to_random_port("%s://%s" % params)
             # XXX this log doesn't appear
             logger.debug("Binded %s to %s://%s." % ((connClass,) + params))
         else:


### PR DESCRIPTION
This fixed 2 bugs:
* Allow passing ":0" as port, as currently the test do, and also use the proper method to bind to a random port.
* Make the non twisted events client use the use the reactor method `callFromThread()` to properly run the callback from a remote thread.