### PR TITLE
[feature] add global flag for disabling the events framework

### DIFF
--- a/changes/feature_7259_disable_events
+++ b/changes/feature_7259_disable_events
@@ -1,0 +1,1 @@
+- Add a flag to disable events framework. Closes: #7259

--- a/src/leap/common/events/__init__.py
+++ b/src/leap/common/events/__init__.py
@@ -14,8 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-
 """
 This is an events mechanism that uses a server to allow for emitting events
 between clients.
@@ -37,13 +35,13 @@ To emit an event, use leap.common.events.emit():
 >>> from leap.common.events import catalog
 >>> emit(catalog.CLIENT_UID)
 """
-
-
 import logging
 import argparse
 
 from leap.common.events import client
 from leap.common.events import server
+from leap.common.events.flags import set_events_enabled
+
 from leap.common.events import catalog
 
 
@@ -52,6 +50,7 @@ __all__ = [
     "unregister",
     "emit",
     "catalog",
+    "set_events_enabled"
 ]
 
 

--- a/src/leap/common/events/client.py
+++ b/src/leap/common/events/client.py
@@ -14,8 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-
 """
 The client end point of the events mechanism.
 
@@ -27,8 +25,6 @@ When a client registers a callback for a given event, it also tells the
 server that it wants to be notified whenever events of that type are sent by
 some other client.
 """
-
-
 import logging
 import collections
 import uuid
@@ -59,6 +55,7 @@ from leap.common.zmq_utils import PUBLIC_KEYS_PREFIX
 from leap.common.events.errors import CallbackAlreadyRegisteredError
 from leap.common.events.server import EMIT_ADDR
 from leap.common.events.server import REG_ADDR
+from leap.common.events import flags
 from leap.common.events import catalog
 
 
@@ -173,9 +170,10 @@ class EventsClient(object):
         :param content: The content of the event.
         :type content: list
         """
-        logger.debug("Emitting event: (%s, %s)" % (event, content))
-        payload = str(event) + b'\0' + pickle.dumps(content)
-        self._send(payload)
+        if flags.EVENTS_ENABLED:
+            logger.debug("Emitting event: (%s, %s)" % (event, content))
+            payload = str(event) + b'\0' + pickle.dumps(content)
+            self._send(payload)
 
     def _handle_event(self, event, content):
         """

--- a/src/leap/common/events/flags.py
+++ b/src/leap/common/events/flags.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# __init__.py
+# Copyright (C) 2015 LEAP
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+"""
+Flags for the events framework.
+"""
+from leap.common.check import leap_assert
+
+EVENTS_ENABLED = True
+
+
+def set_events_enabled(flag):
+    leap_assert(isinstance(flag, bool))
+    global EVENTS_ENABLED
+    EVENTS_ENABLED = flag

--- a/src/leap/common/events/txclient.py
+++ b/src/leap/common/events/txclient.py
@@ -14,8 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
-
-
 """
 The client end point of the events mechanism, implemented using txzmq.
 
@@ -27,8 +25,6 @@ When a client registers a callback for a given event, it also tells the
 server that it wants to be notified whenever events of that type are sent by
 some other client.
 """
-
-
 import logging
 import pickle
 
@@ -62,7 +58,7 @@ class EventsTxClient(TxZmqClientComponent, EventsClient):
     """
 
     def __init__(self, emit_addr=EMIT_ADDR, reg_addr=REG_ADDR,
-            path_prefix=None):
+                 path_prefix=None):
         """
         Initialize the events server.
         """

--- a/src/leap/common/testing/basetest.py
+++ b/src/leap/common/testing/basetest.py
@@ -30,7 +30,10 @@ except ImportError:
 from leap.common.check import leap_assert
 from leap.common.events import server as events_server
 from leap.common.events import client as events_client
+from leap.common.events import flags, set_events_enabled
 from leap.common.files import mkdir_p, check_and_fix_urw_only
+
+set_events_enabled(False)
 
 
 class BaseLeapTest(unittest.TestCase):
@@ -73,12 +76,13 @@ class BaseLeapTest(unittest.TestCase):
 
     @classmethod
     def _init_events(cls):
-        cls._server = events_server.ensure_server(
-            emit_addr="tcp://127.0.0.1:0",
-            reg_addr="tcp://127.0.0.1:0")
-        events_client.configure_client(
-            emit_addr="tcp://127.0.0.1:%d" % cls._server.pull_port,
-            reg_addr="tcp://127.0.0.1:%d" % cls._server.pub_port)
+        if flags.EVENTS_ENABLED:
+            cls._server = events_server.ensure_server(
+                emit_addr="tcp://127.0.0.1:0",
+                reg_addr="tcp://127.0.0.1:0")
+            events_client.configure_client(
+                emit_addr="tcp://127.0.0.1:%d" % cls._server.pull_port,
+                reg_addr="tcp://127.0.0.1:%d" % cls._server.pub_port)
 
     @classmethod
     def tearDownEnv(cls):
@@ -87,8 +91,9 @@ class BaseLeapTest(unittest.TestCase):
         - restores the default PATH and HOME variables
         - removes the temporal folder
         """
-        events_client.shutdown()
-        cls._server.shutdown()
+        if flags.EVENTS_ENABLED:
+            events_client.shutdown()
+            cls._server.shutdown()
 
         os.environ["PATH"] = cls.old_path
         os.environ["HOME"] = cls.old_home


### PR DESCRIPTION
this will be used to allow the unittests to disable the events
framework. this way, emit() will become a passthrough.

note that, until now, the basetest class is making use of the threaded
version of the client, which launches a zmq tornado-based ioloop. this
is wrong, and will have to be addressed in a future commit. we'll have
to make use of the global EVENTS_ENABLED flag in the txclient version
when those changes are made.

Related: #7259