### PR TITLE
remove reactor in threaded client + do not add port to ipc://

### DIFF
--- a/src/leap/common/events/client.py
+++ b/src/leap/common/events/client.py
@@ -174,7 +174,8 @@ class EventsClient(object):
         :type content: list
         """
         logger.debug("Emitting event: (%s, %s)" % (event, content))
-        self._send(str(event) + b'\0' + pickle.dumps(content))
+        payload = str(event) + b'\0' + pickle.dumps(content)
+        self._send(payload)
 
     def _handle_event(self, event, content):
         """
@@ -186,7 +187,7 @@ class EventsClient(object):
         :type content: list
         """
         logger.debug("Handling event %s..." % event)
-        for uid in self._callbacks[event].keys():
+        for uid in self._callbacks[event]:
             callback = self._callbacks[event][uid]
             logger.debug("Executing callback %s." % uid)
             self._run_callback(callback, event, content)
@@ -398,8 +399,7 @@ class EventsClientThread(threading.Thread, EventsClient):
         :param content: The content of the event.
         :type content: list
         """
-        from twisted.internet import reactor
-        reactor.callFromThread(callback, event, *content)
+        self._loop.add_callback(lambda: callback(event, *content))
 
     def register(self, event, callback, uid=None, replace=False):
         """
@@ -422,7 +422,8 @@ class EventsClientThread(threading.Thread, EventsClient):
                 callback identified by the given uid and replace is False.
         """
         self.ensure_client()
-        return EventsClient.register(self, event, callback, uid=uid, replace=replace)
+        return EventsClient.register(
+            self, event, callback, uid=uid, replace=replace)
 
     def unregister(self, event, uid=None):
         """

--- a/src/leap/common/events/zmq_components.py
+++ b/src/leap/common/events/zmq_components.py
@@ -128,16 +128,21 @@ class TxZmqComponent(object):
 
         proto, addr, port = ADDRESS_RE.search(address).groups()
 
-        if port is None or port is '0':
-            params = proto, addr
-            port = socket.bind_to_random_port("%s://%s" % params)
-            # XXX this log doesn't appear
-            logger.debug("Binded %s to %s://%s." % ((connClass,) + params))
+        if proto == "tcp":
+            if port is None or port is '0':
+                params = proto, addr
+                port = socket.bind_to_random_port("%s://%s" % params)
+                logger.debug("Binded %s to %s://%s." % ((connClass,) + params))
+            else:
+                params = proto, addr, int(port)
+                socket.bind("%s://%s:%d" % params)
+                logger.debug(
+                    "Binded %s to %s://%s:%d." % ((connClass,) + params))
         else:
-            params = proto, addr, int(port)
-            socket.bind("%s://%s:%d" % params)
-            # XXX this log doesn't appear
-            logger.debug("Binded %s to %s://%s:%d." % ((connClass,) + params))
+            params = proto, addr
+            socket.bind("%s://%s" % params)
+            logger.debug(
+                "Binded %s to %s://%s" % ((connClass,) + params))
         self._connections.append(connection)
         return connection, port
 


### PR DESCRIPTION
the idea is that we'll be able to use the threaded version of the
client, which makes use of the tornado ioloop, in a non-twisted module,
like the main graphical client probably will be in the near future.