### PR TITLE
Consider events flag when ensuring client

### DIFF
--- a/src/leap/common/events/client.py
+++ b/src/leap/common/events/client.py
@@ -466,7 +466,7 @@ class EventsClientThread(threading.Thread, EventsClient):
         Make sure the events client thread is started.
         """
         with self._lock:
-            if not self.is_alive():
+            if flags.EVENTS_ENABLED and not self.is_alive():
                 self.daemon = True
                 self.start()
                 self._initialized.wait()

--- a/src/leap/common/events/client.py
+++ b/src/leap/common/events/client.py
@@ -508,8 +508,9 @@ def register(event, callback, uid=None, replace=False):
     :raises CallbackAlreadyRegisteredError: when there's already a callback
             identified by the given uid and replace is False.
     """
-    return EventsClientThread.instance().register(
-        event, callback, uid=uid, replace=replace)
+    if flags.EVENTS_ENABLED:
+        return EventsClientThread.instance().register(
+            event, callback, uid=uid, replace=replace)
 
 
 def unregister(event, uid=None):
@@ -524,7 +525,8 @@ def unregister(event, uid=None):
     :param uid: The callback uid.
     :type uid: str
     """
-    return EventsClientThread.instance().unregister(event, uid=uid)
+    if flags.EVENTS_ENABLED:
+        return EventsClientThread.instance().unregister(event, uid=uid)
 
 
 def emit(event, *content):

--- a/src/leap/common/events/client.py
+++ b/src/leap/common/events/client.py
@@ -170,10 +170,9 @@ class EventsClient(object):
         :param content: The content of the event.
         :type content: list
         """
-        if flags.EVENTS_ENABLED:
-            logger.debug("Emitting event: (%s, %s)" % (event, content))
-            payload = str(event) + b'\0' + pickle.dumps(content)
-            self._send(payload)
+        logger.debug("Emitting event: (%s, %s)" % (event, content))
+        payload = str(event) + b'\0' + pickle.dumps(content)
+        self._send(payload)
 
     def _handle_event(self, event, content):
         """
@@ -537,7 +536,8 @@ def emit(event, *content):
     :param content: The content of the event.
     :type content: list
     """
-    return EventsClientThread.instance().emit(event, *content)
+    if flags.EVENTS_ENABLED:
+        return EventsClientThread.instance().emit(event, *content)
 
 
 def instance():

--- a/src/leap/common/tests/test_events.py
+++ b/src/leap/common/tests/test_events.py
@@ -39,13 +39,13 @@ if 'DEBUG' in os.environ:
 class EventsGenericClientTestCase(object):
 
     def setUp(self):
+        flags.set_events_enabled(True)
         self._server = server.ensure_server(
             emit_addr="tcp://127.0.0.1:0",
             reg_addr="tcp://127.0.0.1:0")
         self._client.configure_client(
             emit_addr="tcp://127.0.0.1:%d" % self._server.pull_port,
             reg_addr="tcp://127.0.0.1:%d" % self._server.pub_port)
-        flags.set_events_enabled(True)
 
     def tearDown(self):
         self._client.shutdown()


### PR DESCRIPTION
Change EventsClientThread behavior so it won't start anymore if the events flag is set to False.
Discovered this while running leap_mail tests. It should be better now.