### PR TITLE
[bug] fix typo on dirname usage

### DIFF
--- a/src/leap/common/ca_bundle.py
+++ b/src/leap/common/ca_bundle.py
@@ -39,7 +39,7 @@ def where():
         # we are running in a |PyInstaller| bundle
         path = sys._MEIPASS
         return os.path.join(path, 'cacert.pem')
-    return os.path.join(os.path, dirname(__file__), 'cacert.pem')
+    return os.path.join(os.path.dirname(__file__), 'cacert.pem')
 
 if __name__ == '__main__':
     print(where())


### PR DESCRIPTION
Fix typo introduced on https://github.com/leapcode/leap_pycommon/pull/126/