### PR TITLE
Workaround for deadlock problem in zmq auth

### DIFF
--- a/src/leap/common/events/zmq_components.py
+++ b/src/leap/common/events/zmq_components.py
@@ -25,6 +25,7 @@ import os
 import logging
 import txzmq
 import re
+import time
 
 from abc import ABCMeta
 
@@ -154,6 +155,11 @@ class TxZmqComponent(object):
         :type socket: zmq.Socket
         """
         authenticator = ThreadAuthenticator(self._factory.context)
+
+        # Temporary fix until we understand what the problem is
+        # See https://leap.se/code/issues/7536
+        time.sleep(0.5)
+
         authenticator.start()
         # XXX do not hardcode this here.
         authenticator.allow('127.0.0.1')


### PR DESCRIPTION
This is only a temporary fix, but it would be great if we could merge it while we are searching for the actual root cause.

- See https://leap.se/code/issues/7536
- Actual root cause not identified yet