### PR TITLE
[feat] Get events working on windows

### DIFF
--- a/src/leap/common/events/server.py
+++ b/src/leap/common/events/server.py
@@ -22,6 +22,7 @@ The server for the events mechanism.
 
 
 import logging
+import platform
 import txzmq
 
 from leap.common.zmq_utils import zmq_has_curve
@@ -29,7 +30,8 @@ from leap.common.zmq_utils import zmq_has_curve
 from leap.common.events.zmq_components import TxZmqServerComponent
 
 
-if zmq_has_curve():
+if zmq_has_curve() or platform.system() == "Windows":
+    # Windows doesn't have icp sockets, we need to use always tcp
     EMIT_ADDR = "tcp://127.0.0.1:9000"
     REG_ADDR = "tcp://127.0.0.1:9001"
 else:

--- a/src/leap/common/zmq_utils.py
+++ b/src/leap/common/zmq_utils.py
@@ -19,6 +19,7 @@ Utilities to handle ZMQ certificates.
 """
 import os
 import logging
+import platform
 import stat
 import shutil
 
@@ -52,6 +53,10 @@ def zmq_has_curve():
        `zmq.auth` module is new in version 14.1
        `zmq.has()` is new in version 14.1, new in version libzmq-4.1.
     """
+    if platform.system() == "Windows":
+        # TODO: curve is not working on windows #7919
+        return False
+
     zmq_version = zmq.zmq_version_info()
     pyzmq_version = zmq.pyzmq_version_info()
 


### PR DESCRIPTION
Always use tcp channels and disable curve encryption on the zmq
connections.

- Closes: #7899, #7239
- Related: #7919