### PR TITLE
[bug] close TxAuthenticator properly

### DIFF
--- a/src/leap/common/events/auth.py
+++ b/src/leap/common/events/auth.py
@@ -76,6 +76,10 @@ class TxAuthenticator(ZmqConnection):
                  user_id, metadata]
         self.send(reply)
 
+    def shutdown(self):
+        if self.factory:
+            super(TxAuthenticator, self).shutdown()
+
 
 class TxAuthenticationRequest(ZmqConnection):
 

--- a/src/leap/common/events/zmq_components.py
+++ b/src/leap/common/events/zmq_components.py
@@ -158,6 +158,7 @@ class TxZmqComponent(object):
         public_keys_dir = os.path.join(self._config_prefix, PUBLIC_KEYS_PREFIX)
         auth_req.configure_curve(domain="*", location=public_keys_dir)
         auth_req.shutdown()
+        TxZmqComponent._auth.shutdown()
 
         # This has to be set before binding the socket, that's why this method
         # has to be called before addEndpoints()


### PR DESCRIPTION
otherwise the context.term() does not return.
@kalikaneko I don't know why we have to do this. Do we do something wrong or is this just
a cornercase that happens when running inside our tests?